### PR TITLE
updates to client-tests

### DIFF
--- a/deploy.cfg
+++ b/deploy.cfg
@@ -5,6 +5,8 @@ awe-server = http://redwood.mcs.anl.gov:7080
 shock-server = http://redwood.mcs.anl.gov:7078
 app-directory = app_specs
 ; service-url = 
+; service-host =
+; service-port =
 
 [AppService] 
 
@@ -12,3 +14,5 @@ awe-server = http://redwood.mcs.anl.gov:7080
 shock-server = http://redwood.mcs.anl.gov:7078
 app-directory = app_specs
 ; service-url = 
+; service-host =
+; service-port =

--- a/t/client-tests/as.t
+++ b/t/client-tests/as.t
@@ -15,8 +15,16 @@ else {
 my $url = "http://" . $cfg->param('app_service.service-host') . 
 	  ":" . $cfg->param('app_service.service-port');
 
-ok(system("curl -h > /dev/null 2>&1") == 0, "curl is installed");
-ok(system("curl $url > /dev/null 2>&1") == 0, "$url is reachable");
+my $cmd = 'curl -h > /dev/null 2>&1';
+ok(system($cmd) == 0, "curl is installed");
+
+$cmd = 'curl ' .  $url . ' > /dev/null 2>&1';
+ok(system($cmd) == 0, "$url is reachable");
+
+my $cmd = "curl " . $cfg->param('app_service.service-url') . '>/dev/null 2>&1';
+ok(system($cmd) == 0,
+  $cfg->param('app_service.service-url') . " is reachable"); 
+
 
 # TODO for a pure client side test, remove AWE, Shock, and AppServiceImpl
 BEGIN {

--- a/t/client-tests/as.t
+++ b/t/client-tests/as.t
@@ -9,14 +9,14 @@ if (defined $ENV{KB_DEPLOYMENT_CONFIG} && -e $ENV{KB_DEPLOYMENT_CONFIG}) {
     print "using $ENV{KB_DEPLOYMENT_CONFIG} for configs\n";
 }
 else {
-    $cfg = new Config::Simple(syntax=>'ini');
-    $cfg->param('app_service.service-host', '127.0.0.1');
-    $cfg->param('app_service.service-port', '7109');
+    die "no KB_DEPLOYMENT_CONFIG found";
 }
 
-my $url = "http://" . $cfg->param('handle_service.service-host') . 
-	  ":" . $cfg->param('handle_service.service-port');
+my $url = "http://" . $cfg->param('app_service.service-host') . 
+	  ":" . $cfg->param('app_service.service-port');
 
+ok(system("curl -h > /dev/null 2>&1") == 0, "curl is installed");
+ok(system("curl $url > /dev/null 2>&1") == 0, "$url is reachable");
 
 # TODO for a pure client side test, remove AWE, Shock, and AppServiceImpl
 BEGIN {


### PR DESCRIPTION
added service-url and service-port to app_service/deploy.cfg so that auto-deploy script picks them up and reminds us to set them in the auto-deploy.cfg file. 
