### PR TITLE
Changes for detailed status reporting of apps

### DIFF
--- a/AppService.spec
+++ b/AppService.spec
@@ -67,6 +67,15 @@ module AppService
 
     funcdef query_task_summary() returns (mapping<task_status status, int count> status);
 
+    typedef structure {
+	string stdout_url;
+	string stderr_url;
+	int pid;
+	string hostname;
+	int exitcode;
+    } TaskDetails;
+    funcdef query_task_details(task_id) returns (TaskDetails details);
+
     funcdef enumerate_tasks(int offset, int count)
 	returns (list<Task>);
 };

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,6 @@ compile-typespec: Makefile
 	touch lib/biokbase/$(SERVICE_NAME_PY)/__init__.py 
 	mkdir -p lib/javascript/$(SERVICE_NAME)
 	compile_typespec \
-		--psgi $(SERVICE_PSGI_FILE) \
 		--impl Bio::KBase::$(SERVICE_NAME)::%sImpl \
 		--service Bio::KBase::$(SERVICE_NAME)::Service \
 		--client Bio::KBase::$(SERVICE_NAME)::Client \

--- a/deploy.cfg
+++ b/deploy.cfg
@@ -4,6 +4,19 @@
 awe-server = http://redwood.mcs.anl.gov:7080
 shock-server = http://redwood.mcs.anl.gov:7078
 app-directory = app_specs
+
+;
+; Directory into which task status (stdout/err etc) are written
+;
+
+; task-status-dir =
+
+;
+; AWE client group to submit jobs iwth
+;
+; awe-clientgroup =
+
+
 ; service-url = 
 ; service-host =
 ; service-port =
@@ -13,6 +26,19 @@ app-directory = app_specs
 awe-server = http://redwood.mcs.anl.gov:7080
 shock-server = http://redwood.mcs.anl.gov:7078
 app-directory = app_specs
+
+;
+; Directory into which task status (stdout/err etc) are written
+;
+
+; task-status-dir =
+
+;
+; AWE client group to submit jobs iwth
+;
+; awe-clientgroup =
+
+
 ; service-url = 
 ; service-host =
 ; service-port =

--- a/lib/AppService.psgi
+++ b/lib/AppService.psgi
@@ -8,11 +8,8 @@ use Plack::Builder;
 
 my @dispatch;
 
-{
-    my $obj = Bio::KBase::AppService::AppServiceImpl->new;
-    push(@dispatch, 'AppService' => $obj);
-}
-
+my $obj = Bio::KBase::AppService::AppServiceImpl->new;
+push(@dispatch, 'AppService' => $obj);
 
 my $server = Bio::KBase::AppService::Service->new(instance_dispatch => { @dispatch },
 				allow_get => 0,
@@ -23,6 +20,7 @@ my $rpc_handler = sub { $server->handle_input(@_) };
 $handler = builder {
     mount "/ping" => sub { $server->ping(@_); };
     mount "/auth_ping" => sub { $server->auth_ping(@_); };
+    mount "/task_info" => sub { $obj->_task_info(@_); };
     mount "/" => $rpc_handler;
 };
 

--- a/lib/javascript/AppService/Client.js
+++ b/lib/javascript/AppService/Client.js
@@ -64,6 +64,16 @@ function AppService(url, auth, auth_cb) {
         return json_call_ajax("AppService.query_task_summary", [], 1, _callback, _error_callback);
     };
 
+    this.query_task_details = function (task_id, _callback, _errorCallback) {
+    return json_call_ajax("AppService.query_task_details",
+        [task_id], 1, _callback, _errorCallback);
+};
+
+    this.query_task_details_async = function (task_id, _callback, _error_callback) {
+        deprecationWarning();
+        return json_call_ajax("AppService.query_task_details", [task_id], 1, _callback, _error_callback);
+    };
+
     this.enumerate_tasks = function (offset, count, _callback, _errorCallback) {
     return json_call_ajax("AppService.enumerate_tasks",
         [offset, count], 1, _callback, _errorCallback);

--- a/run-test-server
+++ b/run-test-server
@@ -3,6 +3,6 @@
 export KB_DEPLOYMENT_CONFIG=`pwd`/test.cfg
 export KB_SERVICE_NAME=AppService
 
-shotgun="-L Shotgun"
+#shotgun="-L Shotgun"
 
 plackup $shotgun --listen :5001 lib/AppService.psgi

--- a/test.cfg
+++ b/test.cfg
@@ -4,6 +4,9 @@ awe-server = http://redwood.mcs.anl.gov:7080
 shock-server = http://redwood.mcs.anl.gov:7078
 app-directory = app_specs
 awe-clientgroup = AppService-p3c.theseed.org
+task-status-dir = task-status
+service-url = http://localhost:5001
+
 
 [GenomeAnnotation]
 


### PR DESCRIPTION
Apps now relay stdout/stderr and status to the app service.
Add query_task_details to retrieve this data. Stdout/stderr are retrieved
via REST URLs.