### PR TITLE
Fix and future proof FTP urls

### DIFF
--- a/scripts/App-RNASeq.pl
+++ b/scripts/App-RNASeq.pl
@@ -305,17 +305,17 @@ sub prepare_ref_data_rocket {
     system("mkdir -p $dir");
 
     if ($host){
-        my $tar_url = "ftp://ftp.patricbrc.org/patric2/patric3/genomes/$gid/$gid.RefSeq.ht2.tar";
+        my $tar_url = "ftp://ftp.patricbrc.org/genomes/$gid/$gid.RefSeq.ht2.tar";
         my $out = curl_file($tar_url,"$dir/$gid.RefSeq.ht2.tar");
-        my $fna_url = "ftp://ftp.patricbrc.org/patric2/patric3/genomes/$gid/$gid.RefSeq.fna";
+        my $fna_url = "ftp://ftp.patricbrc.org/genomes/$gid/$gid.RefSeq.fna";
         $out = curl_file($fna_url,"$dir/$gid.RefSeq.fna");
-        my $gff_url = "ftp://ftp.patricbrc.org/patric2/patric3/genomes/$gid/$gid.RefSeq.gff";
+        my $gff_url = "ftp://ftp.patricbrc.org/genomes/$gid/$gid.RefSeq.gff";
         $out = curl_file($gff_url,"$dir/$gid.RefSeq.gff");
     }
 
     else{
         my $api_url = "$data_url/genome_feature/?and(eq(genome_id,$gid),eq(annotation,PATRIC),or(eq(feature_type,CDS),eq(feature_type,tRNA),eq(feature_type,rRNA)))&sort(+accession,+start,+end)&http_accept=application/cufflinks+gff&limit(25000)";
-        my $ftp_url = "ftp://ftp.patricbrc.org/patric2/patric3/genomes/$gid/$gid.PATRIC.gff";
+        my $ftp_url = "ftp://ftp.patricbrc.org/genomes/$gid/$gid.PATRIC.gff";
 
         my $url = $api_url;
         # my $url = $ftp_url;
@@ -323,7 +323,7 @@ sub prepare_ref_data_rocket {
         write_output($out, "$dir/$gid.gff");
 
         $api_url = "$data_url/genome_sequence/?eq(genome_id,$gid)&http_accept=application/sralign+dna+fasta&limit(25000)";
-        $ftp_url = "ftp://ftp.patricbrc.org/patric2/patric3/genomes/$gid/$gid.fna";
+        $ftp_url = "ftp://ftp.patricbrc.org/genomes/$gid/$gid.fna";
 
         $url = $api_url;
         # $url = $ftp_url;


### PR DESCRIPTION
Host RNA-Seq is broken currently due to lack of backwards compatible softlinks on the FTP.
Rather than wait for this to be fixed https://github.com/PATRIC3/patric3_website/issues/1926
Which is causing JIRA (PATRIC-1824) 
I figured its worth going ahead and switching to the long term stable FTP links.
