### PR TITLE
Bug fix: Variation service missing amino acid information #2230

### DIFF
--- a/scripts/App-Variation.pl
+++ b/scripts/App-Variation.pl
@@ -352,8 +352,8 @@ sub prepare_ref_data {
     # my $has_gbk = $out ? 1 : 0;
 
     #Generate genbank file
-    system("p3-gto $gid -o $dir");
-    system("rast-export-genome -i $dir/$gid.gto -o $dir/genes.gbk genbank");
+    system("p3-extract-gto $gid -o $dir/$gid.gto");
+    system("rast_export_genome -i $dir/$gid.gto -o $dir/genes.gbk genbank");
     my $has_gbk = 0;    
     $has_gbk = 1 if -s "$dir/genes.gbk";
 


### PR DESCRIPTION
Use p3-extract-gto and rast_export_genome instead of p3-gto and rast-export-genome to generate the correct gbk files for Variation service. This will ensure that the contig accession numbers match among fna, gff and gbk files.